### PR TITLE
Added optional parameter "addEmptyObject" to keep model consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var reversePopulate = require('mongoose-reverse-populate');
 
 //the next step requires access to the 'Author' and 'Post' mongoose model
 
-Author.find().exec(function(err, authors) {
+Author.find().lean().exec(function(err, authors) {
 
     var opts = {
         modelArray: authors,

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ The options object should contain the following properties...
 * select (object / string) - restrict which fields are returned for your 'related models', see [Query#select](http://mongoosejs.com/docs/api.html#query_Query-select)
 * populate (object / string) - populate your 'related models' with their related models, see [Query#populate](http://mongoosejs.com/docs/api.html#query_Query-populate)
 * sort (object / string) - sort your 'related models', see [Query#sort](http://mongoosejs.com/docs/api.html#query_Query-sort)
+* addEmptyObject (boolean) - If this is set to true, also objects which do not have any children that are reverse populated get a "default" child (if arrayPop is true, an empty array is added, otherwise null). Default: False.
 
 #### callback
 

--- a/index.js
+++ b/index.js
@@ -15,6 +15,18 @@ function reversePopulate(opts, cb) {
 
 	var popResult = populateResult.bind(this, opts.storeWhere, opts.arrayPop);
 
+	// Default: Add no null (or an empty array) to objects that are reverse populated.
+
+	if (opts.addEmptyObject) {
+		opts.modelArray.forEach(function (element) {
+			if (opts.arrayPop) {
+				element[opts.storeWhere] = [];
+			} else {
+				element[opts.storeWhere] = null;
+			}
+		});
+	}
+
 	var query = buildQuery(opts);
 
 	// Do the query


### PR DESCRIPTION
The problem when reverse populating a model is that the returned object hierarchy is not consistent.

Example:
Two authors:
{name: "A", _id: 1} , {name: "B", _id: 2}

Two books:
{name: "book1", author: 1}, {name: "book2", author: 1}

Reverse population of authors with books gives you:

[ { name: "A", _id: 1, books: [{name: "book1", author: 1}, {name: "book2", author: 1}] },
{ name: "B", _id: 2} ]

With the new optional argument "addEmptyObject" set to true it gives you:

[ { name: "A", _id: 1, books: [{name: "book1", author: 1}, {name: "book2", author: 1}] },
{ name: "B", _id: 2, **books: []** } ]

I.e., the author object is kept consistent (every author has the field  books).
