### PR TITLE
Updates to lodash 4 and safely test isArray

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var _ = require("lodash");
+var keyBy = require("lodash/keyBy")
 var REQUIRED_FIELDS = ["modelArray", "storeWhere", "arrayPop", "mongooseModel", "idField"];
 
 function reversePopulate(opts, cb) {
@@ -11,7 +11,7 @@ function reversePopulate(opts, cb) {
 	if (!opts.modelArray.length) return cb(null, opts.modelArray);
 
 	// Transform the model array for easy lookups
-	var modelIndex = _.indexBy(opts.modelArray, "_id");
+	var modelIndex = keyBy(opts.modelArray, "_id");
 
 	var popResult = populateResult.bind(this, opts.storeWhere, opts.arrayPop);
 
@@ -65,7 +65,7 @@ function checkRequired(required, opts) {
 // Build the query string with user provided options
 function buildQuery(opts) {
 	var conditions = opts.filters || {};
-	var ids = _.pluck(opts.modelArray, "_id");
+	var ids = opts.modelArray.map(function (item) { return item._id });
 	conditions[opts.idField] = { $in: ids };
 
 	var query = opts.mongooseModel.find(conditions);
@@ -103,4 +103,3 @@ function populateResult(storeWhere, arrayPop, match, result) {
 		match[storeWhere] = result;
 	}
 }
-

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var keyBy = require("lodash/keyBy")
+var isArray = require("lodash/isArray")
 var REQUIRED_FIELDS = ["modelArray", "storeWhere", "arrayPop", "mongooseModel", "idField"];
 
 function reversePopulate(opts, cb) {
@@ -25,11 +26,8 @@ function reversePopulate(opts, cb) {
 		// Map over results (models to be populated)
 		results.forEach(function(result) {
 
-			// Check if the ID field is an array
-			var isArray = !isNaN(result[opts.idField].length);
-
 			// If the idField is an array, map through this
-			if (isArray) {
+			if (isArray(result[opts.idField])) {
 				result[opts.idField].map(function(resultId) {
 					var match = modelIndex[resultId];
 					// If match found, populate the result inside the match

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "mocha": "^2.2.1"
   },
   "dependencies": {
-    "lodash": "^3.10.0"
+    "lodash": "^4.0.0"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongoose-reverse-populate",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "This module allows you to 'populate' a mongoose model where the relationship ids are stored on another mongoose model that is related to this model",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,7 @@ var reversePopulate = require('../index.js');
 
 var assert = require('assert');
 var async = require('async');
-var _ = require('lodash');
+var difference = require('lodash/difference');
 var mongoose = require('mongoose');
 
 mongoose.connect('mongodb://localhost/mongoose-reverse-populate-test');
@@ -78,7 +78,7 @@ describe('reverse populate', function() {
 							});
 							posts.push(newPost);
 						}
-						
+
 						//save all posts
 						async.each(posts, function(post, cb) {
 							post.save(cb);
@@ -91,7 +91,7 @@ describe('reverse populate', function() {
 
 			});
 		});
-		
+
 		afterEach(function(done) {
 			async.parallel([
 				function(cb) { Category.remove({}, cb); },
@@ -225,7 +225,7 @@ describe('reverse populate', function() {
 		});
 
 		it('should \"sort\" the results returned', function(done) {
-			var sortedTitles = _.pluck(posts, "title").sort();
+			var sortedTitles = posts.map(function(item) { return item.title }).sort();
 
 			var opts = {
 				modelArray: authors,
@@ -240,7 +240,7 @@ describe('reverse populate', function() {
 				var author = authResult[0];
 
 				assert.equal(author.posts.length, 5);
-				var postTitles =  _.pluck(author.posts, "title");
+        var postTitles =  author.posts.map(function(item) { return item.title });
 				assert.deepEqual(sortedTitles, postTitles);
 
 				done();
@@ -377,8 +377,8 @@ var idsMatch = function(arr1, arr2) {
 
 	var arr1IDs = pluckIds(arr1);
 	var arr2IDs = pluckIds(arr2);
-	
-	var diff = _.difference(arr1IDs, arr2IDs);
+
+	var diff = difference(arr1IDs, arr2IDs);
 	assert.equal(diff.length, 0);
 };
 


### PR DESCRIPTION
The current function that test if something is an array was failing for Mongoose 4.5.8, MongoDB 3.2.7, since the test value could be an String:

```
function isArray (t) {
  !isNaN(t.length)
}

isArray([2, 4, 4]) // true
isArray('something') // true (Should be false)
```

This changes updates lodash to version 4 and:
- Use lodash `isArray`
- Replace lodash `pick` for native JavaScript `map`
- Selective imports for lodash (reduce final file size)

Let me know if something is missed.
